### PR TITLE
Fixed alignment + aggregation notebooks (paper example)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,13 @@ original_data/*
 data/*
 .DS_Store
 .idea/
+.vscode/
 .ipynb_checkpoints/
+venv/
 
 *.zarr/
 *.ome.tif
 *.ome.tiff
 *.tif
 *.tiff
+*.h5


### PR DESCRIPTION
Fixed the alignment + aggregation notebook (same example as in the paper). 

Before merging the following plot should be fixed (bug in `spatialdata-plot`):

Expected:
<img width="942" alt="image" src="https://github.com/user-attachments/assets/47ff2c5f-5b16-4ff3-bd3c-7eff52a2b10b">

We get:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/d817b76e-80ae-4142-9c8b-e76bb00ea370">
